### PR TITLE
Set `lock_file` for WORKSPACE-style `maven_install` repository

### DIFF
--- a/pkl/repositories.bzl
+++ b/pkl/repositories.bzl
@@ -63,6 +63,7 @@ def pkl_setup():
         repositories = [
             "https://repo1.maven.org/maven2/",
         ],
+        lock_file = "//pkl/private:pkl_deps_install.json",
     )
 
 project_cache_path_and_dependencies = _project_cache_path_and_dependencies


### PR DESCRIPTION
Without this defined, we'll continue to use `coursier` for dependency resolution and won't use Bazel's own downloader (and therefore will bypass any `downloader.config`).

`bzlmod`
--------

This attribute was already defined in our `MODULE.bazel` configuration, and was missed here.