### PR TITLE
Bump versions to fix WARNINGS for `bazel_skylib`, `platforms`, and `stardoc`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -94,7 +94,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "stardoc",
-    version = "0.6.2",
+    version = "0.7.0",
     dev_dependency = True,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ module(
 
 bazel_dep(
     name = "bazel_skylib",
-    version = "1.5.0",
+    version = "1.7.1",
 )
 bazel_dep(
     name = "rules_jvm_external",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -84,7 +84,7 @@ bazel_dep(
 
 bazel_dep(
     name = "platforms",
-    version = "0.0.8",
+    version = "0.0.10",
 )
 
 bazel_dep(


### PR DESCRIPTION
## Bump `bazel_skylib` to 1.7.1 from 1.5.0

Takes care of the following warning:

```
WARNING: For repository 'bazel_skylib', the root module requires module version bazel_skylib@1.5.0, but got bazel_skylib@1.7.1 in the resolved dependency graph.
```

## Bump `platforms` to 0.0.10 from 0.0.8

Takes care of the following warning:

```
WARNING: For repository 'platforms', the root module requires module version platforms@0.0.8, but got platforms@0.0.10 in the resolved dependency graph.
```

## Bump `stardoc` to 0.6.2 from 0.7.0

Takes care of the following warning:

```
WARNING: For repository 'stardoc', the root module requires module version stardoc@0.6.2, but got stardoc@0.7.0 in the resolved dependency graph.
```