### PR TITLE
chore: ignore examples/pets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,5 +9,5 @@ test --test_output=all
 
 # To update these lines, execute
 # `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
-build --deleted_packages=examples/pkl_project,examples/pkl_project/pkl,examples/simple,tests/integration_tests/example_workspaces/pkl_cache,tests/integration_tests/example_workspaces/simple
-query --deleted_packages=examples/pkl_project,examples/pkl_project/pkl,examples/simple,tests/integration_tests/example_workspaces/pkl_cache,tests/integration_tests/example_workspaces/simple
+build --deleted_packages=examples/pets,examples/pkl_project,examples/pkl_project/pkl,examples/simple,tests/integration_tests/example_workspaces/pkl_cache,tests/integration_tests/example_workspaces/simple
+query --deleted_packages=examples/pets,examples/pkl_project,examples/pkl_project/pkl,examples/simple,tests/integration_tests/example_workspaces/pkl_cache,tests/integration_tests/example_workspaces/simple


### PR DESCRIPTION
This ensures that files in `examples/pets` are only interpreted as plain source files. In particular, `BUILD.bazel` files under that directory will not be interpreted by Bazel to create packages and targets.

This solves issues where, if bazel is manually invoked under the `examples/pets/` WORKSPACE and creates convenience symlinks (`bazel-out/` etc), the IDE might follow these symlinks and spend a lot of time looking for pacakges under there.