### PR TITLE
Fix empty output

### DIFF
--- a/pkl/private/run_pkl_script.sh
+++ b/pkl/private/run_pkl_script.sh
@@ -83,9 +83,10 @@ fi
 
 if [[ "$command" == eval ]]; then
   if [ "$multiple_outputs" == true ]; then
-       mv "${working_dir}/_generated_files"/* "$expected_output"
-
+    if [ -d "${working_dir}/_generated_files" ]; then
+      mv "${working_dir}/_generated_files"/* "$expected_output"
+    fi
   else
-     mv "${working_dir}/${expected_output}" "$expected_output"
+    mv "${working_dir}/${expected_output}" "$expected_output"
   fi
 fi

--- a/tests/pkl_eval/srcs/multipleOutputsEmpty.pkl
+++ b/tests/pkl_eval/srcs/multipleOutputsEmpty.pkl
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+output {
+  files {}
+}


### PR DESCRIPTION
If no output was produced, no `mv` should be done, as it would fail on non-existent directory, e.g.:

```
mv: rename pkl_eval_multiple_empty_output/work/_generated_files/* to bazel-out/darwin_arm64-fastbuild/bin/tests/pkl_eval/pkl_eval_multiple_empty_output/*: No such file or directory
```
