### PR TITLE
Test that our Circle CI image matches the `.bazelversion` in use

### DIFF
--- a/.circleci/BUILD.bazel
+++ b/.circleci/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("//pkl:defs.bzl", "pkl_eval", "pkl_library", "pkl_test")
+
+pkl_library(
+    name = "circleci",
+    srcs = ["config.pkl"],
+)
+
+pkl_eval(
+    name = "config",
+    srcs = ["config.pkl"],
+)
+
+pkl_test(
+    name = "bazel_version_test",
+    srcs = [
+        "bazel_version_test.pkl",
+    ],
+    data = ["//:.bazelversion"],
+    properties = {
+        "bazelVersionPath": "$(location //:.bazelversion)",
+    },
+    deps = [":circleci"],
+)
+
+write_source_files(
+    name = "write_config",
+    files = {
+        "config.yml": ":config",
+    },
+)

--- a/.circleci/bazel_version_test.pkl
+++ b/.circleci/bazel_version_test.pkl
@@ -1,0 +1,24 @@
+amends "pkl:test"
+
+import "config.pkl"
+
+local bazelVersionPath = read("prop:bazelVersionPath")
+local bazelVersion = read("file:\(bazelVersionPath)").text.trim()
+
+local bazelImage: String = new Listing {
+  for (_, job in config.jobs) {
+    when (job.docker != null) {
+      for (docker in job.docker) {
+        when (docker.image.contains("bazel")) {
+          docker.image
+        }
+      }
+    }
+  }
+}.single
+
+facts {
+  [".bazelversion (\(bazelVersion)) matches the version in use for CI (\(bazelImage))"] {
+    bazelImage.endsWith(bazelVersion)
+  }
+}

--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-// File gets rendered to .circleci/config.yml via git hook.
 amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.1.1#/PklCI.pkl"
 
 prb {
@@ -41,7 +40,7 @@ release {
 jobs {
   ["test"] {
     docker {
-      new { image = "gcr.io/bazel-public/bazel:7.2.1" }
+      new { image = "gcr.io/bazel-public/bazel:7.4.0" }
     }
     steps {
       "checkout"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
         command: bazel test --curses=no --color=yes --show_timestamps //...
         name: Bazel tests
     docker:
-    - image: gcr.io/bazel-public/bazel:7.2.1
+    - image: gcr.io/bazel-public/bazel:7.4.0
   github-release:
     steps:
     - attach_workspace:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,10 @@
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
+exports_files([
+    ".bazelversion",
+])
+
 gazelle_binary(
     name = "gazelle_bin",
     languages = ["@bazel_skylib_gazelle_plugin//bzl"],


### PR DESCRIPTION
To prevent any drift.