### PR TITLE
Fix the release script

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -71,7 +71,7 @@ jobs {
       }
       new RunStep {
         name = "Build archive"
-        command = "tar -cavf \(archiveName) --anchored --exclude-from .tar-exclude-from-file.conf *"
+        command = "tar -cavf \(archiveName) -X .tar-exclude-from-file.conf *"
       }
       new RunStep {
         name = "Publish release on GitHub"

--- a/.tar-exclude-from-file.conf
+++ b/.tar-exclude-from-file.conf
@@ -1,6 +1,9 @@
 .circleci
-examples
 bazel-bin
 bazel-out
 bazel-rules_pkl
 bazel-testlogs
+examples
+renovate.json
+scripts
+tests


### PR DESCRIPTION
The version of `tar` being used is the one from `busybox` which takes different parameters to the BSD version used in macOS