### PR TITLE
Exclude directories from the hand-rolled release artifact

### DIFF
--- a/scripts/push-release-artifacts.sh
+++ b/scripts/push-release-artifacts.sh
@@ -8,5 +8,5 @@ VERSION="$1"
 
 ARCHIVE_NAME="rules_pkl-${VERSION}.tar.gz"
 
-git archive --format=tar --prefix=rules_pkl-${VERSION}/ "v${VERSION}" | gzip > "${ARCHIVE_NAME}"
+git archive --format=tar --prefix=rules_pkl-${VERSION}/ "v${VERSION}" ":!tests" ":!.circleci" ":!scripts" | gzip > "${ARCHIVE_NAME}"
 gh release upload "v${VERSION}" "${ARCHIVE_NAME}" --clobber


### PR DESCRIPTION
This has been tested on macOS