### PR TITLE
Mark as being Bazel 7+

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,8 +16,8 @@
 module(
     name = "rules_pkl",
     version = "0.2.0",
-    compatibility_level = 1,
     bazel_compatibility = [">=7.0.0"],
+    compatibility_level = 1,
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.9.4")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,7 @@ module(
     name = "rules_pkl",
     version = "0.2.0",
     compatibility_level = 1,
+    bazel_compatibility = [">=7.0.0"],
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.9.4")


### PR DESCRIPTION
We have a dependency on `rules_jvm_external`, which only works for Bazel 7+ when using `bzlmod`.