### PR TITLE
Update deps: `aspect_bazel_lib` (2.10.0), `bazel_skylib_gazelle_plugin` (1.7.1), `buildifier_prebuilt` (7.3.1), `rules_bazel_integration_test` (0.29.0)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_java", version = "8.6.1")
 bazel_dep(name = "rules_jvm_external", version = "6.6")
 
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.7.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_bazel_integration_test", version = "0.23.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,7 +27,7 @@ bazel_dep(name = "rules_java", version = "8.6.1")
 bazel_dep(name = "rules_jvm_external", version = "6.6")
 
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.7.1", dev_dependency = True)
-bazel_dep(name = "buildifier_prebuilt", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_bazel_integration_test", version = "0.23.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.9.4")
+bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_java", version = "8.6.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,12 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_java", version = "8.6.1")
 bazel_dep(name = "rules_jvm_external", version = "6.6")
 
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_bazel_integration_test", version = "0.23.0", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
+
 pkl = use_extension("//pkl:extensions.bzl", "pkl")
 use_repo(
     pkl,
@@ -62,12 +68,6 @@ use_repo(
     "rules_pkl_deps",
     "unpinned_rules_pkl_deps",
 )
-
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
-bazel_dep(name = "buildifier_prebuilt", version = "6.1.0", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
-bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
-bazel_dep(name = "rules_bazel_integration_test", version = "0.23.0", dev_dependency = True)
 
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,7 +29,7 @@ bazel_dep(name = "rules_jvm_external", version = "6.6")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.7.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
-bazel_dep(name = "rules_bazel_integration_test", version = "0.23.0", dev_dependency = True)
+bazel_dep(name = "rules_bazel_integration_test", version = "0.29.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
 
 pkl = use_extension("//pkl:extensions.bzl", "pkl")

--- a/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
@@ -19,6 +19,8 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
 
+bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
+
 pkl = use_extension("@rules_pkl//pkl:extensions.bzl", "pkl")
 pkl.project(
     name = "mypkl",
@@ -28,12 +30,6 @@ pkl.project(
 use_repo(
     pkl,
     "mypkl",
-)
-
-bazel_dep(
-    name = "rules_python",
-    version = "0.34.0",
-    dev_dependency = True,
 )
 
 python = use_extension(

--- a/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../..",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
+bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")
 
 bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
 

--- a/tests/integration_tests/example_workspaces/pkl_package/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_package/MODULE.bazel
@@ -20,10 +20,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(
-    name = "rules_pkl",
-    version = "0.0.0-local-override",
-)
+bazel_dep(name = "rules_pkl", version = "0.0.0-local-override")
 local_path_override(
     module_name = "rules_pkl",
     path = "../../../..",

--- a/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
@@ -19,6 +19,8 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
 
+bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
+
 pkl = use_extension("@rules_pkl//pkl:extensions.bzl", "pkl")
 pkl.project(
     name = "mypkl",
@@ -40,12 +42,6 @@ pkl.project(
 use_repo(
     pkl,
     "mypkl",
-)
-
-bazel_dep(
-    name = "rules_python",
-    version = "0.34.0",
-    dev_dependency = True,
 )
 
 python = use_extension(

--- a/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../..",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
+bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")
 
 bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
 

--- a/tests/integration_tests/example_workspaces/simple/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/simple/MODULE.bazel
@@ -19,6 +19,8 @@ local_path_override(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
 
+bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
+
 pkl = use_extension("@rules_pkl//pkl:extensions.bzl", "pkl")
 pkl.project(
     name = "mypkl",
@@ -28,12 +30,6 @@ pkl.project(
 use_repo(
     pkl,
     "mypkl",
-)
-
-bazel_dep(
-    name = "rules_python",
-    version = "0.34.0",
-    dev_dependency = True,
 )
 
 python = use_extension(

--- a/tests/integration_tests/example_workspaces/simple/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/simple/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../..",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
+bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")
 
 bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
 


### PR DESCRIPTION
## Updates

### Update `aspect_bazel_lib` to `2.10.0`

Changelog: https://github.com/bazel-contrib/bazel-lib/compare/v2.5.3...v2.10.0

### Update `bazel_skylib_gazelle_plugin` to `1.7.1`

This aligns with the version of `bazel_skylib` we're already pulling in.

Changelog: https://github.com/bazelbuild/bazel-skylib/compare/1.4.1...1.7.1

### Update `buildifier_prebuilt` to `7.3.1`

Changelog: https://github.com/keith/buildifier-prebuilt/compare/6.1.0...7.3.1

### Update `rules_bazel_integration_test` to `0.29.0`

Changelog: https://github.com/bazel-contrib/rules_bazel_integration_test/compare/v0.23.0...v0.29.0