### PR TITLE
`pkl_eval` uses the `short_path` for `entrypoints` files

### DIFF
--- a/pkl/private/pkl.bzl
+++ b/pkl/private/pkl.bzl
@@ -83,7 +83,7 @@ def _prepare_pkl_script(ctx, is_test_target):
         symlinks_json_file.short_path if is_test_target else symlinks_json_file,
         pkl_symlink_tool.short_path if is_test_target else pkl_symlink_tool,
         "--format {}".format(ctx.attr.format) if ctx.attr.format else "",
-        " ".join([f.path for f in (ctx.files.entrypoints or ctx.files.srcs)]),
+        " ".join([f.short_path for f in (ctx.files.entrypoints or ctx.files.srcs)]),
         ctx.attr.multiple_outputs,
         working_dir,
         cache_root_path if len(caches) else "",

--- a/tests/pkl_eval/BUILD.bazel
+++ b/tests/pkl_eval/BUILD.bazel
@@ -216,3 +216,26 @@ sh_test(
         ":pkl_eval_multiple_with_overlapping_directory_outs",
     ],
 )
+
+genrule(
+    name = "gen_entrypoint",
+    outs = ["entrypoint.pkl"],
+    cmd = """
+cat << EOF >> $(location entrypoint.pkl)
+pets = List("dog", "cat", "rabbit", "hamster")
+EOF
+    """,
+)
+
+pkl_eval(
+    name = "pkl_eval_with_genrule_entrypoint",
+    srcs = ["entrypoint.pkl"],
+    entrypoints = ["entrypoint.pkl"],
+    expression = "pets.filter((x) -> x != \"rabbit\")",
+)
+
+diff_test(
+    name = "pkl_eval_with_genrule_entrypoint_diff_test",
+    file1 = ":pkl_eval_with_genrule_entrypoint",
+    file2 = "expected/filtered_animals.pcf",
+)


### PR DESCRIPTION
With `entrypoint.path` in use, we'd see the following error when running `pkl eval`: `Failed processing PKL configuration with entrypoint(s)`.

By using `short_path` we receive a path that `pkl eval` can resolve correctly and evaluate.

This fixes #21.