### PR TITLE
Move the extension to the location recommend by the Bazel devs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,7 @@ filegroup(
         "MODULE.bazel",
         "WORKSPACE",
         "//pkl:all_files",
+        "//pkl/extensions:all_files",
         "//pkl/private:all_files",
         "//pkl/private/org/pkl_lang/bazel/symlinks:all_files",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name
 bazel_dep(name = "rules_bazel_integration_test", version = "0.29.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
 
-pkl = use_extension("//pkl:extensions.bzl", "pkl")
+pkl = use_extension("//pkl/extensions:pkl.bzl", "pkl")
 use_repo(
     pkl,
     "pkl-cli-linux-aarch64",

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -19,7 +19,7 @@ local_path_override(
 
 bazel_dep(name = "rules_pkg", version = "0.10.1")
 
-pkl = use_extension("@rules_pkl//pkl:extensions.bzl", "pkl")
+pkl = use_extension("@rules_pkl//pkl/extensions:pkl.bzl", "pkl")
 pkl.project(
     name = "mypkl",
     pkl_project = "//pkl_project:PklProject",

--- a/pkl/extensions.bzl
+++ b/pkl/extensions.bzl
@@ -15,69 +15,8 @@
 Module extension for using rules_pkl with bzlmod.
 """
 
-load("//pkl:repositories.bzl", "pkl_cli_binaries")
-load("//pkl/private:pkl_project.bzl", "parse_pkl_project_deps_json", _pkl_project = "pkl_project")
-load("//pkl/private:remote_pkl_package.bzl", "remote_pkl_package")
+load("//pkl/extensions:pkl.bzl", _pkl = "pkl")
 
-pkl_project = tag_class(
-    attrs = {
-        "name": attr.string(
-            doc = "Name of the workspace to generate",
-        ),
-        "pkl_project": attr.label(
-            doc = "The PklProject file",
-            allow_single_file = True,
-            mandatory = True,
-        ),
-        "pkl_project_deps": attr.label(
-            doc = "The PklProject.deps.json file",
-            allow_single_file = True,
-            mandatory = True,
-        ),
-        "extra_flags": attr.string_list(
-            doc = """Dictionary of name value pairs used to pass in Pkl external flags.
-                See the Pkl docs: https://pkl-lang.org/main/current/pkl-cli/index.html#command-eval""",
-            default = [],
-        ),
-        "environment": attr.string_dict(
-            doc = """Dictionary of name value pairs used to pass in Pkl env vars.
-                See the Pkl docs: https://pkl-lang.org/main/current/pkl-cli/index.html#command-eval""",
-            default = {},
-        ),
-    },
-)
+print("Please load the `pkl` extension from `//pkl/extensions:pkl.bzl`")
 
-def _toolchain_extension(module_ctx):
-    pkl_cli_binaries()
-
-    workspaces = []
-    for mod in module_ctx.modules:
-        for proj in mod.tags.project:
-            if proj.name in workspaces:
-                fail("May only declare workspace with name %s once." % proj.name)
-            workspaces.append(proj.name)
-
-            # Make sure all the remote files are downloaded and unpacked
-            packages = parse_pkl_project_deps_json(module_ctx.read(proj.pkl_project_deps))
-            for package in packages:
-                remote_pkl_package(
-                    name = package.workspace_name,
-                    url = package.url,
-                    sha256 = package.sha256,
-                )
-
-            # Now set up all the targets that people will rely on in their builds.
-            _pkl_project(
-                name = proj.name,
-                pkl_project = proj.pkl_project,
-                pkl_project_deps = proj.pkl_project_deps,
-                environment = proj.environment,
-                extra_flags = proj.extra_flags,
-            )
-
-pkl = module_extension(
-    implementation = _toolchain_extension,
-    tag_classes = {
-        "project": pkl_project,
-    },
-)
+pkl = _pkl

--- a/pkl/extensions.bzl
+++ b/pkl/extensions.bzl
@@ -17,6 +17,7 @@ Module extension for using rules_pkl with bzlmod.
 
 load("//pkl/extensions:pkl.bzl", _pkl = "pkl")
 
+# buildifier: disable=print
 print("Please load the `pkl` extension from `//pkl/extensions:pkl.bzl`")
 
 pkl = _pkl

--- a/pkl/extensions/BUILD.bazel
+++ b/pkl/extensions/BUILD.bazel
@@ -1,0 +1,8 @@
+filegroup(
+    name = "all_files",
+    srcs = glob(["*"]),
+    visibility = [
+        "//:__pkg__",
+        "//tests/integration_tests:__subpackages__",
+    ],
+)

--- a/pkl/extensions/pkl.bzl
+++ b/pkl/extensions/pkl.bzl
@@ -1,0 +1,83 @@
+# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module extension for using rules_pkl with bzlmod.
+"""
+
+load("//pkl:repositories.bzl", "pkl_cli_binaries")
+load("//pkl/private:pkl_project.bzl", "parse_pkl_project_deps_json", _pkl_project = "pkl_project")
+load("//pkl/private:remote_pkl_package.bzl", "remote_pkl_package")
+
+pkl_project = tag_class(
+    attrs = {
+        "name": attr.string(
+            doc = "Name of the workspace to generate",
+        ),
+        "pkl_project": attr.label(
+            doc = "The PklProject file",
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "pkl_project_deps": attr.label(
+            doc = "The PklProject.deps.json file",
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "extra_flags": attr.string_list(
+            doc = """Dictionary of name value pairs used to pass in Pkl external flags.
+                See the Pkl docs: https://pkl-lang.org/main/current/pkl-cli/index.html#command-eval""",
+            default = [],
+        ),
+        "environment": attr.string_dict(
+            doc = """Dictionary of name value pairs used to pass in Pkl env vars.
+                See the Pkl docs: https://pkl-lang.org/main/current/pkl-cli/index.html#command-eval""",
+            default = {},
+        ),
+    },
+)
+
+def _toolchain_extension(module_ctx):
+    pkl_cli_binaries()
+
+    workspaces = []
+    for mod in module_ctx.modules:
+        for proj in mod.tags.project:
+            if proj.name in workspaces:
+                fail("May only declare workspace with name %s once." % proj.name)
+            workspaces.append(proj.name)
+
+            # Make sure all the remote files are downloaded and unpacked
+            packages = parse_pkl_project_deps_json(module_ctx.read(proj.pkl_project_deps))
+            for package in packages:
+                remote_pkl_package(
+                    name = package.workspace_name,
+                    url = package.url,
+                    sha256 = package.sha256,
+                )
+
+            # Now set up all the targets that people will rely on in their builds.
+            _pkl_project(
+                name = proj.name,
+                pkl_project = proj.pkl_project,
+                pkl_project_deps = proj.pkl_project_deps,
+                environment = proj.environment,
+                extra_flags = proj.extra_flags,
+            )
+
+pkl = module_extension(
+    implementation = _toolchain_extension,
+    tag_classes = {
+        "project": pkl_project,
+    },
+)

--- a/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")
 
 bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
 
-pkl = use_extension("@rules_pkl//pkl:extensions.bzl", "pkl")
+pkl = use_extension("@rules_pkl//pkl/extensions:pkl.bzl", "pkl")
 pkl.project(
     name = "mypkl",
     pkl_project = "@//:PklProject",

--- a/tests/integration_tests/example_workspaces/pkl_package/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_package/MODULE.bazel
@@ -26,7 +26,7 @@ local_path_override(
     path = "../../../..",
 )
 
-pkl = use_extension("@rules_pkl//pkl:extensions.bzl", "pkl")
+pkl = use_extension("@rules_pkl//pkl/extensions:pkl.bzl", "pkl")
 pkl.project(
     name = "mypklproject",
     pkl_project = "@//:PklProject",

--- a/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")
 
 bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
 
-pkl = use_extension("@rules_pkl//pkl:extensions.bzl", "pkl")
+pkl = use_extension("@rules_pkl//pkl/extensions:pkl.bzl", "pkl")
 pkl.project(
     name = "mypkl",
 

--- a/tests/integration_tests/example_workspaces/simple/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/simple/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")
 
 bazel_dep(name = "rules_python", version = "0.34.0", dev_dependency = True)
 
-pkl = use_extension("@rules_pkl//pkl:extensions.bzl", "pkl")
+pkl = use_extension("@rules_pkl//pkl/extensions:pkl.bzl", "pkl")
 pkl.project(
     name = "mypkl",
     pkl_project = "@//:PklProject",


### PR DESCRIPTION
Following the advice in https://bazel.build/external/extension#put_each_extension_in_a_separate_file