### PR TITLE
Rename all Java code generation rules to be prefixed with `pkl_java_`

### DIFF
--- a/docs/rules_pkl_docs.md
+++ b/docs/rules_pkl_docs.md
@@ -192,7 +192,7 @@ Generate documentation website for Pkl files.
 | :------------- | :------------- | :------------- |
 | <a id="pkl_doc-name"></a>name |  A unique name for this target.   |  none |
 | <a id="pkl_doc-srcs"></a>srcs |  The Pkl source files to be documented.   |  none |
-| <a id="pkl_doc-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility   |  none |
+| <a id="pkl_doc-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility.   |  none |
 
 
 <a id="pkl_java_library"></a>
@@ -218,7 +218,7 @@ Create a compiled JAR of Java source files generated from Pkl source files.
 | <a id="pkl_java_library-generate_getters"></a>generate_getters |  Generate private final fields and public getter methods instead of public final fields. Defaults to True.   |  `None` |
 | <a id="pkl_java_library-deps"></a>deps |  Other targets to include in the Pkl module path when building this Java library. Must be pkl_* targets.   |  `[]` |
 | <a id="pkl_java_library-tags"></a>tags |  Bazel tags to add to this target.   |  `[]` |
-| <a id="pkl_java_library-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility   |  none |
+| <a id="pkl_java_library-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility.   |  none |
 
 
 <a id="pkl_test_suite"></a>

--- a/docs/rules_pkl_docs.md
+++ b/docs/rules_pkl_docs.md
@@ -199,29 +199,6 @@ Create a compiled JAR of Java source files generated from Pkl source files.
 | <a id="pkl_config_java_library-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility   |  none |
 
 
-<a id="pkl_config_src"></a>
-
-## pkl_config_src
-
-<pre>
-load("@rules_pkl//pkl:defs.bzl", "pkl_config_src")
-
-pkl_config_src(<a href="#pkl_config_src-name">name</a>, <a href="#pkl_config_src-files">files</a>, <a href="#pkl_config_src-module_path">module_path</a>, <a href="#pkl_config_src-kwargs">kwargs</a>)
-</pre>
-
-Create a JAR containing the generated Java source files from Pkl files.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="pkl_config_src-name"></a>name |  A unique name for this target.   |  none |
-| <a id="pkl_config_src-files"></a>files |  The Pkl source files used to generate the Java source files.   |  none |
-| <a id="pkl_config_src-module_path"></a>module_path |  List of Java module targets. Must export provide the JavaInfo provider.   |  `None` |
-| <a id="pkl_config_src-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility   |  none |
-
-
 <a id="pkl_doc"></a>
 
 ## pkl_doc

--- a/docs/rules_pkl_docs.md
+++ b/docs/rules_pkl_docs.md
@@ -173,32 +173,6 @@ pkl_toolchain(<a href="#pkl_toolchain-name">name</a>, <a href="#pkl_toolchain-cl
 | <a id="pkl_toolchain-cli"></a>cli |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
-<a id="pkl_config_java_library"></a>
-
-## pkl_config_java_library
-
-<pre>
-load("@rules_pkl//pkl:defs.bzl", "pkl_config_java_library")
-
-pkl_config_java_library(<a href="#pkl_config_java_library-name">name</a>, <a href="#pkl_config_java_library-files">files</a>, <a href="#pkl_config_java_library-module_path">module_path</a>, <a href="#pkl_config_java_library-generate_getters">generate_getters</a>, <a href="#pkl_config_java_library-deps">deps</a>, <a href="#pkl_config_java_library-tags">tags</a>, <a href="#pkl_config_java_library-kwargs">kwargs</a>)
-</pre>
-
-Create a compiled JAR of Java source files generated from Pkl source files.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="pkl_config_java_library-name"></a>name |  A unique name for this target.   |  none |
-| <a id="pkl_config_java_library-files"></a>files |  The Pkl files that are used to generate the Java source files.   |  none |
-| <a id="pkl_config_java_library-module_path"></a>module_path |  List of Java module targets. Must export provide the JavaInfo provider.   |  `[]` |
-| <a id="pkl_config_java_library-generate_getters"></a>generate_getters |  Generate private final fields and public getter methods instead of public final fields. Defaults to True.   |  `None` |
-| <a id="pkl_config_java_library-deps"></a>deps |  Other targets to include in the Pkl module path when building this Java library. Must be pkl_* targets.   |  `[]` |
-| <a id="pkl_config_java_library-tags"></a>tags |  Bazel tags to add to this target.   |  `[]` |
-| <a id="pkl_config_java_library-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility   |  none |
-
-
 <a id="pkl_doc"></a>
 
 ## pkl_doc
@@ -219,6 +193,32 @@ Generate documentation website for Pkl files.
 | <a id="pkl_doc-name"></a>name |  A unique name for this target.   |  none |
 | <a id="pkl_doc-srcs"></a>srcs |  The Pkl source files to be documented.   |  none |
 | <a id="pkl_doc-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility   |  none |
+
+
+<a id="pkl_java_library"></a>
+
+## pkl_java_library
+
+<pre>
+load("@rules_pkl//pkl:defs.bzl", "pkl_java_library")
+
+pkl_java_library(<a href="#pkl_java_library-name">name</a>, <a href="#pkl_java_library-srcs">srcs</a>, <a href="#pkl_java_library-module_path">module_path</a>, <a href="#pkl_java_library-generate_getters">generate_getters</a>, <a href="#pkl_java_library-deps">deps</a>, <a href="#pkl_java_library-tags">tags</a>, <a href="#pkl_java_library-kwargs">kwargs</a>)
+</pre>
+
+Create a compiled JAR of Java source files generated from Pkl source files.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="pkl_java_library-name"></a>name |  A unique name for this target.   |  none |
+| <a id="pkl_java_library-srcs"></a>srcs |  The Pkl files that are used to generate the Java source files.   |  none |
+| <a id="pkl_java_library-module_path"></a>module_path |  List of Java module targets. Must export provide the JavaInfo provider.   |  `[]` |
+| <a id="pkl_java_library-generate_getters"></a>generate_getters |  Generate private final fields and public getter methods instead of public final fields. Defaults to True.   |  `None` |
+| <a id="pkl_java_library-deps"></a>deps |  Other targets to include in the Pkl module path when building this Java library. Must be pkl_* targets.   |  `[]` |
+| <a id="pkl_java_library-tags"></a>tags |  Bazel tags to add to this target.   |  `[]` |
+| <a id="pkl_java_library-kwargs"></a>kwargs |  Further keyword arguments. E.g. visibility   |  none |
 
 
 <a id="pkl_test_suite"></a>

--- a/pkl/defs.bzl
+++ b/pkl/defs.bzl
@@ -23,7 +23,6 @@ load(
 load(
     "//pkl/private:pkl_codegen.bzl",
     _pkl_config_java_library = "pkl_config_java_library",
-    _pkl_config_src = "pkl_config_src",
 )
 load(
     "//pkl/private:pkl_doc.bzl",
@@ -50,7 +49,6 @@ load(
 
 pkl_codegen_java_toolchain = _pkl_codegen_java_toolchain
 pkl_config_java_library = _pkl_config_java_library
-pkl_config_src = _pkl_config_src
 pkl_doc = _pkl_doc
 pkl_doc_toolchain = _pkl_doc_toolchain
 pkl_library = _pkl_library

--- a/pkl/defs.bzl
+++ b/pkl/defs.bzl
@@ -21,8 +21,8 @@ load(
     _pkl_test = "pkl_test",
 )
 load(
-    "//pkl/private:pkl_codegen.bzl",
-    _pkl_config_java_library = "pkl_config_java_library",
+    "//pkl/private:pkl_codegen_java.bzl",
+    _pkl_java_library = "pkl_java_library",
 )
 load(
     "//pkl/private:pkl_doc.bzl",
@@ -47,8 +47,6 @@ load(
     _pkl_toolchain = "pkl_toolchain",
 )
 
-pkl_codegen_java_toolchain = _pkl_codegen_java_toolchain
-pkl_config_java_library = _pkl_config_java_library
 pkl_doc = _pkl_doc
 pkl_doc_toolchain = _pkl_doc_toolchain
 pkl_library = _pkl_library
@@ -57,3 +55,6 @@ pkl_package = _pkl_package
 pkl_test = _pkl_test
 pkl_test_suite = _pkl_test_suite
 pkl_toolchain = _pkl_toolchain
+
+pkl_codegen_java_toolchain = _pkl_codegen_java_toolchain
+pkl_java_library = _pkl_java_library

--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -1,18 +1,20 @@
 """
-Implementation for 'pkl_config_src' and 'pkl_config_java_library' macros.
+Implementation for 'pkl_java_library' macro.
 """
 
 load("@rules_jvm_external//:defs.bzl", "artifact")
+load("@rules_pkl//pkl/private:providers.bzl", "PklCacheInfo", "PklFileInfo")
 
 def _to_short_path(f, _expander):
     return f.tree_relative_path + "=" + f.path
 
-def _zipit(ctx, outfile, files):
+# TODO: Investigate if this can be replaced with `pkg_zip` from `rules_pkg`.
+def _zipit(ctx, outfile, srcs):
     zip_args = ctx.actions.args()
     zip_args.add_all("cC", [outfile.path])
-    zip_args.add_all(files, map_each = _to_short_path)
+    zip_args.add_all(srcs, map_each = _to_short_path)
     ctx.actions.run(
-        inputs = files,
+        inputs = srcs,
         outputs = [outfile],
         executable = ctx.executable._zip,
         arguments = [zip_args],
@@ -23,7 +25,7 @@ def _pkl_java_jar_impl(ctx):
     modules = depset(transitive = [depset(dep[JavaInfo].runtime_output_jars) for dep in ctx.attr.module_path]).to_list()
     java_codegen_toolchain = ctx.toolchains["//pkl:codegen_toolchain_type"]
 
-    # Generate Java from PKL
+    # Generate Java from Pkl
     outdir = ctx.actions.declare_directory(ctx.attr.name, sibling = None)
     gen_args = ctx.actions.args()
 
@@ -33,10 +35,10 @@ def _pkl_java_jar_impl(ctx):
     if ctx.attr.generate_getters:
         gen_args.add_all(["--generate-getters"])
     gen_args.add_all("-o", [outdir.path])
-    gen_args.add_all(ctx.files.files)
+    gen_args.add_all(ctx.files.srcs)
 
     ctx.actions.run(
-        inputs = ctx.files.files + modules,
+        inputs = ctx.files.srcs + modules,
         outputs = [outdir],
         executable = java_codegen_toolchain.codegen_cli,
         arguments = [gen_args],
@@ -51,7 +53,7 @@ def _pkl_java_jar_impl(ctx):
     _zipit(
         ctx = ctx,
         outfile = ctx.outputs.out,
-        files = [outdir],
+        srcs = [outdir],
     )
 
     # Return JAR
@@ -63,12 +65,12 @@ _pkl_java_jar = rule(
 
         Args:
           name: A unique name for this target.
-          files: The Pkl source files used to generate the Java source files.
+          srcs: The Pkl source files used to generate the Java source files.
           module_path: List of Java module targets. Must export provide the JavaInfo provider.
           **kwargs: Further keyword arguments. E.g. visibility
         """,
     attrs = {
-        "files": attr.label_list(
+        "srcs": attr.label_list(
             mandatory = True,
             allow_files = [".pkl"],
             doc = "The Pkl source files.",
@@ -98,12 +100,12 @@ _pkl_java_jar = rule(
     ],
 )
 
-def pkl_config_java_library(name, files, module_path = [], generate_getters = None, deps = [], tags = [], **kwargs):
+def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps = [], tags = [], **kwargs):
     """Create a compiled JAR of Java source files generated from Pkl source files.
 
     Args:
         name: A unique name for this target.
-        files: The Pkl files that are used to generate the Java source files.
+        srcs: The Pkl files that are used to generate the Java source files.
         module_path: List of Java module targets. Must export provide the JavaInfo provider.
         generate_getters: Generate private final fields and public getter methods instead of public final fields. Defaults to True.
         deps: Other targets to include in the Pkl module path when building this Java library. Must be pkl_* targets.
@@ -114,7 +116,7 @@ def pkl_config_java_library(name, files, module_path = [], generate_getters = No
 
     _pkl_java_jar(
         name = name_generated_code,
-        files = files,
+        srcs = srcs,
         generate_getters = generate_getters,
         module_path = module_path,
         out = "{name}_codegen.srcjar".format(name = name_generated_code),
@@ -126,14 +128,14 @@ def pkl_config_java_library(name, files, module_path = [], generate_getters = No
     # Ensure that there are no duplicate entries in the deps
     all_deps = depset(
         pkl_deps + module_path,
-        transitive = [depset([dep]) for dep in deps],
+        transitive = [depset([dep]) for dep in deps if PklFileInfo in dep or PklCacheInfo in dep],
     )
 
     native.java_library(
         name = name,
         srcs = [name_generated_code],
         deps = all_deps.to_list(),
-        resources = files,
+        resources = srcs,
         tags = tags + [] if "no-lint" in tags else ["no-lint"],
         **kwargs
     )

--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -67,7 +67,7 @@ _pkl_java_src_jar = rule(
           name: A unique name for this target.
           srcs: The Pkl source files used to generate the Java source files.
           module_path: List of Java module targets. Must export provide the JavaInfo provider.
-          **kwargs: Further keyword arguments. E.g. visibility
+          **kwargs: Further keyword arguments. E.g. visibility.
         """,
     attrs = {
         "srcs": attr.label_list(
@@ -110,7 +110,7 @@ def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps
         generate_getters: Generate private final fields and public getter methods instead of public final fields. Defaults to True.
         deps: Other targets to include in the Pkl module path when building this Java library. Must be pkl_* targets.
         tags: Bazel tags to add to this target.
-        **kwargs: Further keyword arguments. E.g. visibility
+        **kwargs: Further keyword arguments. E.g. visibility.
     """
     name_generated_code = name + "_pkl"
 

--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -21,7 +21,7 @@ def _zipit(ctx, outfile, srcs):
         progress_message = "Writing via zip: %s" % outfile.basename,
     )
 
-def _pkl_java_jar_impl(ctx):
+def _pkl_java_src_jar_impl(ctx):
     modules = depset(transitive = [depset(dep[JavaInfo].runtime_output_jars) for dep in ctx.attr.module_path]).to_list()
     java_codegen_toolchain = ctx.toolchains["//pkl:codegen_toolchain_type"]
 
@@ -59,8 +59,8 @@ def _pkl_java_jar_impl(ctx):
     # Return JAR
     return OutputGroupInfo(out = [outjar])
 
-_pkl_java_jar = rule(
-    _pkl_java_jar_impl,
+_pkl_java_src_jar = rule(
+    _pkl_java_src_jar_impl,
     doc = """Create a JAR containing the generated Java source files from Pkl files.
 
         Args:
@@ -114,7 +114,7 @@ def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps
     """
     name_generated_code = name + "_pkl"
 
-    _pkl_java_jar(
+    _pkl_java_src_jar(
         name = name_generated_code,
         srcs = srcs,
         generate_getters = generate_getters,

--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -112,6 +112,10 @@ def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps
         tags: Bazel tags to add to this target.
         **kwargs: Further keyword arguments. E.g. visibility.
     """
+    depsets = [depset([dep]) for dep in deps if PklFileInfo in dep or PklCacheInfo in dep]
+    if len(depsets) != len(deps):
+        fail("`deps` were provided, but there were no `PklFileInfo` or `PklCacheInfo` providers present within:", deps)
+
     name_generated_code = name + "_pkl"
 
     _pkl_java_src_jar(
@@ -128,7 +132,7 @@ def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps
     # Ensure that there are no duplicate entries in the deps
     all_deps = depset(
         pkl_deps + module_path,
-        transitive = [depset([dep]) for dep in deps if PklFileInfo in dep or PklCacheInfo in dep],
+        transitive = depsets,
     )
 
     native.java_library(

--- a/pkl/private/pkl_doc.bzl
+++ b/pkl/private/pkl_doc.bzl
@@ -89,7 +89,7 @@ def pkl_doc(name, srcs, **kwargs):
     Args:
         name: A unique name for this target.
         srcs: The Pkl source files to be documented.
-        **kwargs: Further keyword arguments. E.g. visibility
+        **kwargs: Further keyword arguments. E.g. visibility.
     """
     if "out" not in kwargs:
         kwargs["out"] = name + "_docs.zip"

--- a/tests/pkl_codegen_java/BUILD.bazel
+++ b/tests/pkl_codegen_java/BUILD.bazel
@@ -1,20 +1,11 @@
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("//pkl:defs.bzl", "pkl_config_java_library", "pkl_config_src")
+load("//pkl:defs.bzl", "pkl_config_java_library")
 
-pkl_config_src(
+pkl_config_java_library(
     name = "base",
     files = [
         "srcs/base.pkl",
     ],
-)
-
-java_library(
-    name = "gen_lib",
-    srcs = [":base"],
-    deps = [artifact(
-        "org.pkl-lang:pkl-tools",
-        repository_name = "rules_pkl_deps",
-    )],
 )
 
 java_test(
@@ -35,13 +26,6 @@ java_test(
             "org.pkl-lang:pkl-tools",
             repository_name = "rules_pkl_deps",
         ),
-        ":gen_lib",
-    ],
-)
-
-pkl_config_java_library(
-    name = "pkl_config_java_lib",
-    files = [
-        "srcs/base.pkl",
+        ":base",
     ],
 )

--- a/tests/pkl_codegen_java/BUILD.bazel
+++ b/tests/pkl_codegen_java/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("//pkl:defs.bzl", "pkl_config_java_library")
+load("@rules_pkl//pkl:defs.bzl", "pkl_java_library")
 
-pkl_config_java_library(
+pkl_java_library(
     name = "base",
-    files = [
+    srcs = [
         "srcs/base.pkl",
     ],
 )


### PR DESCRIPTION
This is in preparation for supporting more code generation rules, to provide some level of consistency of naming.

# Commits

## Make `pkl_config_src` private, and rename it to `_pkl_java_jar`

The produced `.jar` file will only contain the generated `.java` sources, and won't have the required runtime dependencies, which are provided by `pkl_config_java_library`.

## Rename `pkl_config_java_library` to `pkl_java_library`