### PR TITLE
Update `gazelle` to 0.36.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,7 +27,7 @@ bazel_dep(name = "rules_java", version = "8.6.1")
 bazel_dep(name = "rules_jvm_external", version = "6.6")
 
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_bazel_integration_test", version = "0.29.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
 


### PR DESCRIPTION
- Release: https://github.com/bazel-contrib/bazel-gazelle/releases/tag/v0.36.0
- Compare: https://github.com/bazel-contrib/bazel-gazelle/compare/v0.35.0...v0.36.0