### PR TITLE
Configure `hawkeye` to update license headers

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -60,6 +60,10 @@ jobs {
         command = "bazel run --config=circleci buildifier"
       }
       new RunStep {
+        name = "Check licenses"
+        command = "bazel run --config=circleci //scripts:hawkeye -- check --fail-if-unknown"
+      }
+      new RunStep {
         name = "Gazelle"
         command = "bazel run --config=circleci //:gazelle && git diff --exit-code"
       }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
         command: bazel run --config=circleci buildifier
         name: Buildifier lint
     - run:
+        command: bazel run --config=circleci //scripts:hawkeye -- check --fail-if-unknown
+        name: Check licenses
+    - run:
         command: bazel run --config=circleci //:gazelle && git diff --exit-code
         name: Gazelle
     - run:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """apple/rules_pkl"""
 
 module(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -80,3 +80,34 @@ use_repo(
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_7_4_1",
 )
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+hawkeye_coordinates = [
+    {
+        "name": "hawkeye-aarch64-apple-darwin",
+        "url": "https://github.com/korandoru/hawkeye/releases/download/v6.0.2/hawkeye-aarch64-apple-darwin.tar.xz",
+        "sha256": "9f300ad84201e500c4eb09ed710239797d2a6a17de5b7c08e1d3af1704ca6bb7",
+    },
+    {
+        "name": "hawkeye-x86_64-apple-darwin",
+        "url": "https://github.com/korandoru/hawkeye/releases/download/v6.0.2/hawkeye-x86_64-apple-darwin.tar.xz",
+        "sha256": "6f8850adb9204b6218f4912fb987106a71fcd8d742ce20227697ddccc44cec38",
+    },
+    {
+        "name": "hawkeye-x86_64-unknown-linux-gnu",
+        "url": "https://github.com/korandoru/hawkeye/releases/download/v6.0.2/hawkeye-x86_64-unknown-linux-gnu.tar.xz",
+        "sha256": "d5b9d3cdb4293ac84fa27e5021c77b6c062c61071760ab05fcacfbec1ac14850",
+    },
+]
+
+[
+    http_archive(
+        name = coords["name"],
+        build_file = "//scripts:hawkeye.BUILD",
+        sha256 = coords["sha256"],
+        strip_prefix = coords["name"],
+        url = coords["url"],
+    )
+    for coords in hawkeye_coordinates
+]

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
 
 stardoc_with_diff_test(

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,0 +1,30 @@
+headerPath = "scripts/license-header.txt"
+
+includes = [
+    "*.BUILD",
+    "*.bazel",
+    "*.bzl",
+    "*.java",
+    "*.pkl",
+    "*.py",
+    "*.sh",
+    "PklProject",
+]
+
+excludes = [
+    "examples",
+]
+
+[git]
+attrs = 'auto'
+ignore = 'auto'
+
+[properties]
+copyrightOwner = "Apple Inc. and the Pkl project authors"
+
+[mapping.SCRIPT_STYLE]
+extensions = [
+    "BUILD",
+    "bazel",
+    "bzl",
+]

--- a/pkl/BUILD.bazel
+++ b/pkl/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_jvm_external//:defs.bzl", "artifact")

--- a/pkl/defs.bzl
+++ b/pkl/defs.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Public API re-exports
 """

--- a/pkl/extensions.bzl
+++ b/pkl/extensions.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Module extension for using rules_pkl with bzlmod.
 """

--- a/pkl/extensions/BUILD.bazel
+++ b/pkl/extensions/BUILD.bazel
@@ -1,3 +1,17 @@
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),

--- a/pkl/extensions/pkl.bzl
+++ b/pkl/extensions/pkl.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Module extension for using rules_pkl with bzlmod.
 """

--- a/pkl/private/BUILD.bazel
+++ b/pkl/private/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 filegroup(

--- a/pkl/private/constants.bzl
+++ b/pkl/private/constants.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Constants.
 """

--- a/pkl/private/org/pkl_lang/bazel/symlinks/BUILD.bazel
+++ b/pkl/private/org/pkl_lang/bazel/symlinks/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 

--- a/pkl/private/org/pkl_lang/bazel/symlinks/Symlinks.java
+++ b/pkl/private/org/pkl_lang/bazel/symlinks/Symlinks.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //===----------------------------------------------------------------------===//
 // Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
 //

--- a/pkl/private/org/pkl_lang/bazel/symlinks/Symlinks.java
+++ b/pkl/private/org/pkl_lang/bazel/symlinks/Symlinks.java
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-//===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//===----------------------------------------------------------------------===//
 package org.pkl_lang.bazel.symlinks;
 
 import com.google.gson.Gson;

--- a/pkl/private/pkl.bzl
+++ b/pkl/private/pkl.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Implementation for 'pkl_eval' and 'pkl_test' rules.
 """

--- a/pkl/private/pkl_cache.bzl
+++ b/pkl/private/pkl_cache.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Declaring packages _expected_ to be in the cache (populated by pkl_deps repository rule).
 """

--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -1,3 +1,17 @@
+# Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Implementation for 'pkl_java_library' macro.
 """

--- a/pkl/private/pkl_doc.bzl
+++ b/pkl/private/pkl_doc.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Implementation of 'pkl_doc' macro.
 """

--- a/pkl/private/pkl_library.bzl
+++ b/pkl/private/pkl_library.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Implementation of 'pkl_library' rule.
 """

--- a/pkl/private/pkl_package.bzl
+++ b/pkl/private/pkl_package.bzl
@@ -1,16 +1,17 @@
-## Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     https://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Implementation of the pkl project package command as a Bazel rule.
 """

--- a/pkl/private/pkl_package_names.bzl
+++ b/pkl/private/pkl_package_names.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Functionality for working with Pkl Package names.
 """

--- a/pkl/private/pkl_project.bzl
+++ b/pkl/private/pkl_project.bzl
@@ -1,16 +1,16 @@
-## Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     https://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Repository rule for parsing the PklProject.deps.json and the PklProject file.

--- a/pkl/private/pkl_project_rule.bzl
+++ b/pkl/private/pkl_project_rule.bzl
@@ -1,16 +1,17 @@
-## Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     https://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Implementation of 'pkl_project_rule'.
 """

--- a/pkl/private/pkl_test_suite.bzl
+++ b/pkl/private/pkl_test_suite.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Implementation of 'pkl_test_suite' macro.
 """

--- a/pkl/private/providers.bzl
+++ b/pkl/private/providers.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Definition for Pkl Providers.
 """

--- a/pkl/private/remote_pkl_package.bzl
+++ b/pkl/private/remote_pkl_package.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Repository rule for downloading remote Pkl packages.
 """

--- a/pkl/private/repositories.bzl
+++ b/pkl/private/repositories.bzl
@@ -1,3 +1,17 @@
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Repository helper functions"""
 
 load("//pkl/private:providers.bzl", "PklFileInfo")

--- a/pkl/private/run_pkl_script.sh
+++ b/pkl/private/run_pkl_script.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkl/private/toolchain.bzl
+++ b/pkl/private/toolchain.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Implementation of toolchains for Pkl.
 """

--- a/pkl/repositories.bzl
+++ b/pkl/repositories.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Repository rules for defining dependencies.
 """

--- a/pkl/workspace.bzl
+++ b/pkl/workspace.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Export rules_pkl dependencies.
 """

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,0 +1,38 @@
+# Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+You can check license files with:
+
+```
+bazel run //scripts:hawkeye -- check --fail-if-unknown
+```
+
+You can update header comments with:
+
+```
+bazel run //scripts:hawkeye -- format --fail-if-unknown
+```
+"""
+
+alias(
+    name = "hawkeye",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin": "@hawkeye-aarch64-apple-darwin//:hawkeye",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@hawkeye-x86_64-apple-darwin//:hawkeye",
+        "@bazel_tools//src/conditions:linux_x86_64": "@hawkeye-x86_64-unknown-linux-gnu//:hawkeye",
+        "//conditions:default": "@hawkeye-aarch64-apple-darwin//:hawkeye",
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/scripts/hawkeye.BUILD
+++ b/scripts/hawkeye.BUILD
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["hawkeye"])

--- a/scripts/hawkeye.BUILD
+++ b/scripts/hawkeye.BUILD
@@ -1,3 +1,17 @@
+# Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["hawkeye"])

--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,0 +1,13 @@
+Copyright ©{{ " " }}{%- if attrs.git_file_modified_year != attrs.git_file_created_year -%}{{ attrs.git_file_created_year }}-{{ attrs.git_file_modified_year }}{%- else -%}{{ attrs.git_file_created_year }}{%- endif -%}{{ " " }}{{ props["copyrightOwner"] }}. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/scripts/prep-bcr-pr.sh
+++ b/scripts/prep-bcr-pr.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eufo pipefail
 
 BCR_REPO="$1"

--- a/scripts/push-release-artifacts.sh
+++ b/scripts/push-release-artifacts.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eufo pipefail
 
 VERSION="$1"

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load(":repositories_test.bzl", "project_cache_path_and_dependencies_test_suite")
 
 package(default_visibility = ["//visibility:private"])

--- a/tests/integration_tests/BUILD.bazel
+++ b/tests/integration_tests/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load(
     "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",

--- a/tests/integration_tests/example_workspaces/pkl_cache/BUILD.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_cache/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@rules_pkl//pkl:defs.bzl", "pkl_eval")
 load("//:poison_cache.bzl", "poisoned_pkl_cache")

--- a/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 bazel_dep(name = "rules_pkl", version = "1.0")
 local_path_override(
     module_name = "rules_pkl",

--- a/tests/integration_tests/example_workspaces/pkl_cache/PklProject
+++ b/tests/integration_tests/example_workspaces/pkl_cache/PklProject
@@ -1,3 +1,19 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
 amends "pkl:Project"
 
 dependencies {

--- a/tests/integration_tests/example_workspaces/pkl_cache/example.pkl
+++ b/tests/integration_tests/example_workspaces/pkl_cache/example.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 amends "@io.k8s/api/core/v1/ConfigMap.pkl"
 
 metadata {

--- a/tests/integration_tests/example_workspaces/pkl_cache/poison_cache.bzl
+++ b/tests/integration_tests/example_workspaces/pkl_cache/poison_cache.bzl
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Repository Rule to poison a Pkl cache item for testing.
 """

--- a/tests/integration_tests/example_workspaces/pkl_cache/poison_cache_script.sh
+++ b/tests/integration_tests/example_workspaces/pkl_cache/poison_cache_script.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/integration_tests/example_workspaces/pkl_package/BUILD.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_package/BUILD.bazel
@@ -1,10 +1,10 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/integration_tests/example_workspaces/pkl_package/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_package/MODULE.bazel
@@ -1,18 +1,16 @@
-###############################################################################
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-###############################################################################
 
 module(
     name = "rules_pkl_tests_pkl_package",

--- a/tests/integration_tests/example_workspaces/pkl_package/PklProject
+++ b/tests/integration_tests/example_workspaces/pkl_package/PklProject
@@ -1,3 +1,19 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
 amends "pkl:Project"
 
 dependencies {

--- a/tests/integration_tests/example_workspaces/pkl_package/pkl_package_test_one.py
+++ b/tests/integration_tests/example_workspaces/pkl_package/pkl_package_test_one.py
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 import unittest
 import zipfile

--- a/tests/integration_tests/example_workspaces/pkl_package/pkl_package_test_two.py
+++ b/tests/integration_tests/example_workspaces/pkl_package/pkl_package_test_two.py
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 import unittest
 import zipfile

--- a/tests/integration_tests/example_workspaces/pkl_package/srcs/pkg1/tortoise.pkl
+++ b/tests/integration_tests/example_workspaces/pkl_package/srcs/pkg1/tortoise.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/integration_tests/example_workspaces/pkl_package/srcs/pkg2/BUILD.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_package/srcs/pkg2/BUILD.bazel
@@ -1,10 +1,10 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/integration_tests/example_workspaces/pkl_package/srcs/pkg2/hare.pkl
+++ b/tests/integration_tests/example_workspaces/pkl_package/srcs/pkg2/hare.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/integration_tests/example_workspaces/pkl_project/BUILD.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_project/BUILD.bazel
@@ -1,10 +1,10 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 bazel_dep(name = "rules_pkl", version = "1.0")
 local_path_override(
     module_name = "rules_pkl",

--- a/tests/integration_tests/example_workspaces/pkl_project/PklProject
+++ b/tests/integration_tests/example_workspaces/pkl_project/PklProject
@@ -1,3 +1,19 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
 amends "pkl:Project"
 
 package {

--- a/tests/integration_tests/example_workspaces/pkl_project/pkl_project_test.py
+++ b/tests/integration_tests/example_workspaces/pkl_project/pkl_project_test.py
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unittest
 
 class MyTestCase(unittest.TestCase):

--- a/tests/integration_tests/example_workspaces/simple/BUILD.bazel
+++ b/tests/integration_tests/example_workspaces/simple/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@rules_pkl//pkl:defs.bzl", "pkl_eval", "pkl_test")
 

--- a/tests/integration_tests/example_workspaces/simple/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/simple/MODULE.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 bazel_dep(name = "rules_pkl", version = "1.0")
 local_path_override(
     module_name = "rules_pkl",

--- a/tests/integration_tests/example_workspaces/simple/PklProject
+++ b/tests/integration_tests/example_workspaces/simple/PklProject
@@ -1,3 +1,19 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
 amends "pkl:Project"
 
 dependencies {

--- a/tests/integration_tests/example_workspaces/simple/example.pkl
+++ b/tests/integration_tests/example_workspaces/simple/example.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 amends "@io.k8s/api/core/v1/ConfigMap.pkl"
 
 metadata {

--- a/tests/integration_tests/example_workspaces/simple/metadataDepsTest.pkl
+++ b/tests/integration_tests/example_workspaces/simple/metadataDepsTest.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 amends "pkl:test"
 
 import "@io.k8s/api/core/v1/ConfigMap.pkl"

--- a/tests/pkl_codegen_java/BUILD.bazel
+++ b/tests/pkl_codegen_java/BUILD.bazel
@@ -1,3 +1,17 @@
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("@rules_pkl//pkl:defs.bzl", "pkl_java_library")
 

--- a/tests/pkl_codegen_java/TestPklCodegen.java
+++ b/tests/pkl_codegen_java/TestPklCodegen.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/tests/pkl_codegen_java/srcs/base.pkl
+++ b/tests/pkl_codegen_java/srcs/base.pkl
@@ -1,3 +1,19 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
 module org.dogs
 
 class Dog {

--- a/tests/pkl_codegen_java/srcs/litter.pkl
+++ b/tests/pkl_codegen_java/srcs/litter.pkl
@@ -1,3 +1,19 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
 amends "base.pkl"
 
 puppies = new Litter {

--- a/tests/pkl_doc/BUILD.bazel
+++ b/tests/pkl_doc/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//pkl:defs.bzl", "pkl_doc")
 

--- a/tests/pkl_doc/PklDocTest.java
+++ b/tests/pkl_doc/PklDocTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.pkl_doc;
 
 import com.google.devtools.build.runfiles.Runfiles;

--- a/tests/pkl_doc/srcs/doc-package-info.pkl
+++ b/tests/pkl_doc/srcs/doc-package-info.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 /// Animals Package
 amends "pkl:DocPackageInfo"
 

--- a/tests/pkl_doc/srcs/rabbits.pkl
+++ b/tests/pkl_doc/srcs/rabbits.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 /// An Animal
 module com.animals.Rabbits
 

--- a/tests/pkl_eval/BUILD.bazel
+++ b/tests/pkl_eval/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("//pkl:defs.bzl", "pkl_eval", "pkl_library")
 

--- a/tests/pkl_eval/srcs/foo/BUILD.bazel
+++ b/tests/pkl_eval/srcs/foo/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("//pkl:defs.bzl", "pkl_library")
 
 pkl_library(

--- a/tests/pkl_eval/srcs/foo/pets.pkl
+++ b/tests/pkl_eval/srcs/foo/pets.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,4 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 pets = List("dog", "cat", "rabbit", "hamster")

--- a/tests/pkl_eval/srcs/generatedOverride.pkl
+++ b/tests/pkl_eval/srcs/generatedOverride.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 import "../generated.pkl"
 
 myPets = generated.pets

--- a/tests/pkl_eval/srcs/multipleOutputs.pkl
+++ b/tests/pkl_eval/srcs/multipleOutputs.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 transit {
   Make = "Ford"
   Model = "Transit"

--- a/tests/pkl_eval/srcs/multipleOutputsEmpty.pkl
+++ b/tests/pkl_eval/srcs/multipleOutputsEmpty.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/pkl_eval/srcs/multipleOutputsOverlappingDirectory.pkl
+++ b/tests/pkl_eval/srcs/multipleOutputsOverlappingDirectory.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 panda {
   Make = "Fiat"
   Model = "Panda"

--- a/tests/pkl_eval/srcs/pets.pkl
+++ b/tests/pkl_eval/srcs/pets.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,4 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 pets = List("dog", "cat", "rabbit", "hamster")

--- a/tests/pkl_eval/srcs/petsOverride.pkl
+++ b/tests/pkl_eval/srcs/petsOverride.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 import "pets.pkl"
 
 myPets = pets.pets

--- a/tests/pkl_eval/srcs/petsWithLibDep.pkl
+++ b/tests/pkl_eval/srcs/petsWithLibDep.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 import "foo/pets.pkl"
 
 myPets = pets.pets

--- a/tests/pkl_eval/verify_pkl_eval_output.sh
+++ b/tests/pkl_eval/verify_pkl_eval_output.sh
@@ -1,17 +1,18 @@
 #! /bin/bash
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -e
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd -P)

--- a/tests/pkl_library/BUILD.bazel
+++ b/tests/pkl_library/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//pkl:defs.bzl", "pkl_library")
 

--- a/tests/pkl_library/TransitiveSourcesTest.java
+++ b/tests/pkl_library/TransitiveSourcesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.pkl_library;
 
 import com.google.devtools.build.runfiles.Runfiles;

--- a/tests/pkl_library/srcs/animals.pkl
+++ b/tests/pkl_library/srcs/animals.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,3 +13,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+

--- a/tests/pkl_library/srcs/horse.pkl
+++ b/tests/pkl_library/srcs/horse.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,3 +13,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+

--- a/tests/pkl_test/BUILD.bazel
+++ b/tests/pkl_test/BUILD.bazel
@@ -1,16 +1,17 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 load("//pkl:defs.bzl", "pkl_library", "pkl_test", "pkl_test_suite")
 
 pkl_test(

--- a/tests/pkl_test/srcs/EmptyTest.pkl
+++ b/tests/pkl_test/srcs/EmptyTest.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,4 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 amends "pkl:test"

--- a/tests/pkl_test/srcs/cat.pkl
+++ b/tests/pkl_test/srcs/cat.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,5 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 WhiskersCount: Int = 6
 CatName: String = "Puddles"

--- a/tests/pkl_test/srcs/catTest.pkl
+++ b/tests/pkl_test/srcs/catTest.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 amends "pkl:test"
 
 import "cat.pkl"

--- a/tests/pkl_test/srcs/dogs.pkl
+++ b/tests/pkl_test/srcs/dogs.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,4 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 myDogs = Set("Bruce", "Bruno", "Poodles")

--- a/tests/pkl_test/srcs/dogsTest.pkl
+++ b/tests/pkl_test/srcs/dogsTest.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 amends "pkl:test"
 
 import "dogs.pkl"

--- a/tests/pkl_test/srcs/generatedPklTest.pkl
+++ b/tests/pkl_test/srcs/generatedPklTest.pkl
@@ -1,11 +1,11 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
+
 amends "pkl:test"
 
 import "../generated.pkl"

--- a/tests/repositories_test.bzl
+++ b/tests/repositories_test.bzl
@@ -1,3 +1,17 @@
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for public interfaces of //pkl:repositories.bzl"""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")

--- a/tests/toolchain/BUILD.bazel
+++ b/tests/toolchain/BUILD.bazel
@@ -1,10 +1,10 @@
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/toolchain/test_current_toolchain.sh
+++ b/tests/toolchain/test_current_toolchain.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -eu
 
 version=$(eval "$1" --version)

--- a/tests/toolchain/test_current_toolchain_runtime.sh
+++ b/tests/toolchain/test_current_toolchain_runtime.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
-# Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -eu
 
 version=$(eval "$PKL_BIN" --version)

--- a/tests/version/BUILD.bazel
+++ b/tests/version/BUILD.bazel
@@ -1,3 +1,17 @@
+# Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 py_binary(
     name = "version_test",
     srcs = ["version_test.py"],

--- a/tests/version/version_test.py
+++ b/tests/version/version_test.py
@@ -1,3 +1,17 @@
+# Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 This test file is implemented as a `py_binary` to allow us to pass in the
 WORKSPACE_ROOT, which isn't available to us through `py_test`, which is


### PR DESCRIPTION
You can test this with:

```
bazel run //scripts:hawkeye -- check --fail-if-unknown
```

You can update header comments with:

```
bazel run //scripts:hawkeye -- format --fail-if-unknown
```

Ref: https://github.com/korandoru/hawkeye/