### PR TITLE
[bzlmod] Export the `pkl-tools` dep from ruleset to better support `bzlmod`-enabled builds

### DIFF
--- a/pkl/private/BUILD.bazel
+++ b/pkl/private/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_jvm_external//:defs.bzl", "artifact")
 
 filegroup(
     name = "all_files",
@@ -35,5 +36,15 @@ bzl_library(
 sh_binary(
     name = "run_pkl_script",
     srcs = ["run_pkl_script.sh"],
+    visibility = ["//visibility:public"],
+)
+
+# Export the `pkl-tools` library from the ruleset so `bzlmod`-enabled builds
+# can link against it.
+java_library(
+    name = "pkl-tools",
+    exports = [
+        artifact("org.pkl-lang:pkl-tools", repository_name = "rules_pkl_deps")
+    ],
     visibility = ["//visibility:public"],
 )

--- a/pkl/private/BUILD.bazel
+++ b/pkl/private/BUILD.bazel
@@ -43,8 +43,11 @@ sh_binary(
 # can link against it.
 java_library(
     name = "pkl-tools",
-    exports = [
-        artifact("org.pkl-lang:pkl-tools", repository_name = "rules_pkl_deps")
-    ],
     visibility = ["//visibility:public"],
+    exports = [
+        artifact(
+            "org.pkl-lang:pkl-tools",
+            repository_name = "rules_pkl_deps",
+        ),
+    ],
 )

--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -16,7 +16,6 @@
 Implementation for 'pkl_java_library' macro.
 """
 
-load("@rules_jvm_external//:defs.bzl", "artifact")
 load("@rules_pkl//pkl/private:providers.bzl", "PklCacheInfo", "PklFileInfo")
 
 def _to_short_path(f, _expander):
@@ -141,7 +140,6 @@ def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps
         tags = tags,
     )
 
-#    pkl_deps = [artifact("org.pkl-lang:pkl-tools", repository_name = "rules_pkl_deps")]
     pkl_deps = [Label("//pkl/private:pkl-tools")]
 
     # Ensure that there are no duplicate entries in the deps

--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -141,7 +141,8 @@ def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps
         tags = tags,
     )
 
-    pkl_deps = [artifact("org.pkl-lang:pkl-tools", repository_name = "rules_pkl_deps")]
+#    pkl_deps = [artifact("org.pkl-lang:pkl-tools", repository_name = "rules_pkl_deps")]
+    pkl_deps = [Label("//pkl/private:pkl-tools")]
 
     # Ensure that there are no duplicate entries in the deps
     all_deps = depset(


### PR DESCRIPTION
This is because of the way that repo visibility works with `bzlmod` enabled builds. While we can see the `rules_pkl_deps` repo from `rules_pkl` itself, anything loads `rules_pkl` as a `bazel_dep` cannot. To avoid this problem, we can re-export the target from `rules_pkl` and make people depend upon that.