### PR TITLE
Fix: extension pkl reported incorrect imports of repositories

### DIFF
--- a/pkl/extensions/pkl.bzl
+++ b/pkl/extensions/pkl.bzl
@@ -49,11 +49,11 @@ pkl_project = tag_class(
 )
 
 def _toolchain_extension(module_ctx):
-    pkl_cli_binaries()
+    cli_binaries = pkl_cli_binaries()
 
     workspaces = []
     seen_packages = []
-    direct_deps = []
+    direct_deps = cli_binaries
     direct_dev_deps = []
     for mod in module_ctx.modules:
         for proj in mod.tags.project:

--- a/pkl/repositories.bzl
+++ b/pkl/repositories.bzl
@@ -24,23 +24,45 @@ load("//pkl/private:repositories.bzl", _project_cache_path_and_dependencies = "r
 
 DEFAULT_PKL_VERSION = "0.28.2"
 
-def pkl_cli_binaries():
-    version = DEFAULT_PKL_VERSION
+def pkl_cli_binaries(version = DEFAULT_PKL_VERSION):
+    """
+    Sets up the `http_file` repositories for the Pkl binaries.
+
+    Args:
+      version: the Pkl version you want to use
+
+    Returns:
+      A list of the binary names.
+    """
+    binary_names = []
+
     for arch, sha256 in VERSIONS[version].items():
+        cli_name = "pkl-cli-{arch}".format(arch = arch)
+        binary_names.append(cli_name)
+
         maybe(
             http_file,
-            name = "pkl-cli-{arch}".format(arch = arch),
+            name = cli_name,
             url = "https://github.com/apple/pkl/releases/download/{version}/pkl-{arch}".format(version = version, arch = arch),
             sha256 = sha256,
             executable = True,
         )
 
-def pkl_setup():
-    pkl_cli_binaries()
+    return binary_names
+
+def pkl_setup(version = DEFAULT_PKL_VERSION):
+    """
+    Setup all repositories for Pkl.
+
+    Args:
+          version: the Pkl version you want to use
+    """
+
+    pkl_cli_binaries(version)
 
     maven_install(
         name = "rules_pkl_deps",
-        artifacts = PKL_DEPS[DEFAULT_PKL_VERSION],
+        artifacts = PKL_DEPS[version],
         repositories = [
             "https://repo1.maven.org/maven2/",
         ],

--- a/tests/integration_tests/example_workspaces/multiple_pkl_projects/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/multiple_pkl_projects/MODULE.bazel
@@ -29,4 +29,12 @@ pkl.project(
     pkl_project = "@//project2:PklProject",
     pkl_project_deps = "@//project2:PklProject.deps.json",
 )
-use_repo(pkl, "alsopkl", "mypkl")
+use_repo(
+    pkl,
+    "alsopkl",
+    "mypkl",
+    "pkl-cli-linux-aarch64",
+    "pkl-cli-linux-amd64",
+    "pkl-cli-macos-aarch64",
+    "pkl-cli-macos-amd64",
+)

--- a/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_cache/MODULE.bazel
@@ -31,6 +31,10 @@ pkl.project(
 use_repo(
     pkl,
     "mypkl",
+    "pkl-cli-linux-aarch64",
+    "pkl-cli-linux-amd64",
+    "pkl-cli-macos-aarch64",
+    "pkl-cli-macos-amd64",
 )
 
 python = use_extension(

--- a/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/pkl_project/MODULE.bazel
@@ -43,6 +43,10 @@ pkl.project(
 use_repo(
     pkl,
     "mypkl",
+    "pkl-cli-linux-aarch64",
+    "pkl-cli-linux-amd64",
+    "pkl-cli-macos-aarch64",
+    "pkl-cli-macos-amd64",
 )
 
 python = use_extension(

--- a/tests/integration_tests/example_workspaces/simple/MODULE.bazel
+++ b/tests/integration_tests/example_workspaces/simple/MODULE.bazel
@@ -31,6 +31,10 @@ pkl.project(
 use_repo(
     pkl,
     "mypkl",
+    "pkl-cli-linux-aarch64",
+    "pkl-cli-linux-amd64",
+    "pkl-cli-macos-aarch64",
+    "pkl-cli-macos-amd64",
 )
 
 python = use_extension(


### PR DESCRIPTION
Fixes the following `WARNING`:

```
(10:58:19) WARNING: /home/ubuntu/project/MODULE.bazel:35:20: The module extension pkl defined in @rules_pkl//pkl/extensions:pkl.bzl reported incorrect imports of repositories via use_repo():

Imported, but reported as indirect dependencies by the extension:
    pkl-cli-linux-aarch64, pkl-cli-linux-amd64, pkl-cli-macos-aarch64, pkl-cli-macos-amd64

Fix the use_repo calls by running 'bazel mod tidy'.
```