### PR TITLE
Remove `github-release` workflow

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -27,16 +27,6 @@ main {
   }
 }
 
-release {
-  jobs {
-    new {
-      ["github-release"] {
-        context = "pkl-github-release"
-      }
-    }
-  }
-}
-
 local bazelCacheKeys: Listing<String> = new {
   #"v1-bazel-cache-{{ arch }}-{{ checksum "MODULE.bazel" }}"#
   #"v1-bazel-cache-{{ arch }}-"#
@@ -89,37 +79,6 @@ jobs {
       }
       new StoreTestResults {
         path = bazelTestLogs
-      }
-    }
-  }
-  ["github-release"] {
-    docker {
-      new { image = "maniator/gh:v2.40.1" }
-    }
-    steps {
-      local archiveName = "rules_pkl-$VERSION.tar.gz"
-      new AttachWorkspaceStep { at = "." }
-      new RunStep {
-        name = "Setup environment"
-        // There SHOULD be a better way to extract the bazel module version from the bazel metadata.
-        command = """
-          echo "export VERSION=$(bazel mod path rules_pkl | awk -F'@' '/rules_pkl/{ print substr($2, 1, length($2)-1) }')" >> $BASH_ENV
-          """
-      }
-      new RunStep {
-        name = "Build archive"
-        command = "tar -cavf \(archiveName) -X .tar-exclude-from-file.conf *"
-      }
-      new RunStep {
-        name = "Publish release on GitHub"
-        command = #"""
-          gh release create "${CIRCLE_TAG}" \
-            --title "${CIRCLE_TAG}" \
-            --target "${CIRCLE_SHA1}" \
-            --verify-tag \
-            --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-            \#(archiveName)
-          """#
       }
     }
   }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,27 +39,6 @@ jobs:
         path: /tmp/bazel-testlogs
     docker:
     - image: gcr.io/bazel-public/bazel:7.6.1
-  github-release:
-    steps:
-    - attach_workspace:
-        at: '.'
-    - run:
-        command: echo "export VERSION=$(bazel mod path rules_pkl | awk -F'@' '/rules_pkl/{ print substr($2, 1, length($2)-1) }')" >> $BASH_ENV
-        name: Setup environment
-    - run:
-        command: tar -cavf rules_pkl-$VERSION.tar.gz -X .tar-exclude-from-file.conf *
-        name: Build archive
-    - run:
-        command: |-
-          gh release create "${CIRCLE_TAG}" \
-            --title "${CIRCLE_TAG}" \
-            --target "${CIRCLE_SHA1}" \
-            --verify-tag \
-            --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-            rules_pkl-$VERSION.tar.gz
-        name: Publish release on GitHub
-    docker:
-    - image: maniator/gh:v2.40.1
 workflows:
   prb:
     jobs:
@@ -81,12 +60,3 @@ workflows:
       equal:
       - main
       - << pipeline.git.branch >>
-  release:
-    jobs:
-    - github-release:
-        context: pkl-github-release
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v?\d+\.\d+\.\d+$/


### PR DESCRIPTION
It's currently broken, and needs to align with the set of instructions outlined in `RELEASING.md` which are currently manual.

At some future date, those instructions should be turned into something that can successfully handle the release for us, including opening a PR to `bazelbuild/bazel-central-registry`.