### PR TITLE
Integration test against Bazel 7 and Bazel 8; resolve paths as `short_path` for binaries and tests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -93,11 +93,13 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version = "7.6.1")
+bazel_binaries.download(version = "8.2.1")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_7_6_1",
+    "build_bazel_bazel_8_2_1",
 )
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/pkl/private/toolchain.bzl
+++ b/pkl/private/toolchain.bzl
@@ -27,7 +27,7 @@ def _pkl_toolchain_impl(ctx):
     )
 
     make_variables = platform_common.TemplateVariableInfo({
-        "PKL_BIN": ctx.executable.cli.short_path if JavaInfo in ctx.attr.cli else ctx.executable.cli.path,
+        "PKL_BIN": ctx.executable.cli.short_path,
     })
     toolchain_info = platform_common.ToolchainInfo(
         cli = ctx.attr.cli,
@@ -51,7 +51,7 @@ pkl_toolchain = rule(
         ),
         "_symlink_tool": attr.label(
             cfg = "exec",
-            default = "//pkl/private/org/pkl_lang/bazel/symlinks",
+            default = "@rules_pkl//pkl/private/org/pkl_lang/bazel/symlinks",
             executable = True,
         ),
     },
@@ -68,7 +68,7 @@ pkl_codegen_java_toolchain = rule(
     _pkl_codegen_java_toolchain_impl,
     attrs = {
         "cli": attr.label(
-            default = "//pkl:pkl_codegen_java_cli",
+            default = "@rules_pkl//pkl:pkl_codegen_java_cli",
             executable = True,
             cfg = "exec",
         ),
@@ -86,14 +86,14 @@ pkl_doc_toolchain = rule(
     attrs = {
         "cli": attr.label(
             cfg = "exec",
-            default = "//pkl:pkl_doc_cli",
+            default = "@rules_pkl//pkl:pkl_doc_cli",
             executable = True,
         ),
     },
 )
 
 def _current_pkl_toolchain_impl(ctx):
-    toolchain = ctx.toolchains[str(Label("//pkl:toolchain_type"))]
+    toolchain = ctx.toolchains[str(Label("@rules_pkl//pkl:toolchain_type"))]
     all_runfiles = ctx.runfiles(files = [toolchain.cli[DefaultInfo].files_to_run.executable])
     all_runfiles = all_runfiles.merge(toolchain.cli[DefaultInfo].default_runfiles)
     return [

--- a/tests/integration_tests/BUILD.bazel
+++ b/tests/integration_tests/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load(
     "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
-    "bazel_integration_test",
+    "bazel_integration_tests",
     "default_test_runner",
     "integration_test_utils",
 )
@@ -24,9 +24,9 @@ default_test_runner(
     name = "simple_test_runner",
 )
 
-bazel_integration_test(
+bazel_integration_tests(
     name = "multiple_pkl_projects_test",
-    bazel_version = bazel_binaries.versions.current,
+    bazel_versions = bazel_binaries.versions.all,
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS + [
         # Add 'no-sandbox' tag to disable running this test target in the Bazel sandbox to prevent
         # file permission issues when accessing/writing to the cache.
@@ -39,9 +39,9 @@ bazel_integration_test(
     workspace_path = "example_workspaces/multiple_pkl_projects",
 )
 
-bazel_integration_test(
-    name = "pkl_deps_test",
-    bazel_version = bazel_binaries.versions.current,
+bazel_integration_tests(
+    name = "simple_test",
+    bazel_versions = bazel_binaries.versions.all,
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS + [
         # Add 'no-sandbox' tag to disable running this test target in the Bazel sandbox to prevent
         # file permission issues when accessing/writing to the cache.
@@ -54,9 +54,9 @@ bazel_integration_test(
     workspace_path = "example_workspaces/simple",
 )
 
-bazel_integration_test(
+bazel_integration_tests(
     name = "pkl_cache_poisoning_test",
-    bazel_version = bazel_binaries.versions.current,
+    bazel_versions = bazel_binaries.versions.all,
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS + [
         # Add 'no-sandbox' tag to disable running this test target in the Bazel sandbox to prevent
         # file permission issues when accessing/writing to the cache.
@@ -69,9 +69,9 @@ bazel_integration_test(
     workspace_path = "example_workspaces/pkl_cache",
 )
 
-bazel_integration_test(
+bazel_integration_tests(
     name = "pkl_project_test",
-    bazel_version = bazel_binaries.versions.current,
+    bazel_versions = bazel_binaries.versions.all,
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS + [
         # Add 'no-sandbox' tag to disable running this test target in the Bazel sandbox to prevent
         # file permission issues when accessing/writing to the cache.
@@ -89,11 +89,22 @@ bazel_integration_test(
 # bazel test //...
 test_suite(
     name = "all_integration_tests",
-    tests = [
-        ":multiple_pkl_projects_test",
-        ":pkl_cache_poisoning_test",
-        ":pkl_deps_test",
-        ":pkl_project_test",
-    ],
+    tests =
+        integration_test_utils.bazel_integration_test_names(
+            ":multiple_pkl_projects_test",
+            bazel_binaries.versions.all,
+        ) +
+        integration_test_utils.bazel_integration_test_names(
+            ":pkl_cache_poisoning_test",
+            bazel_binaries.versions.all,
+        ) +
+        integration_test_utils.bazel_integration_test_names(
+            ":simple_test",
+            bazel_binaries.versions.all,
+        ) +
+        integration_test_utils.bazel_integration_test_names(
+            ":pkl_project_test",
+            bazel_binaries.versions.all,
+        ),
     visibility = ["//:__subpackages__"],
 )

--- a/tests/toolchain/BUILD.bazel
+++ b/tests/toolchain/BUILD.bazel
@@ -29,7 +29,7 @@ genrule(
         "test_current_toolchain.sh",
     ],
     outs = ["out.txt"],
-    cmd = "DEFAULT_PKL_VERSION={} bash tests/toolchain/test_current_toolchain.sh $(PKL_BIN) > $@".format(DEFAULT_PKL_VERSION),
+    cmd = "DEFAULT_PKL_VERSION={} bash tests/toolchain/test_current_toolchain.sh $(execpath :current_toolchain) > $@".format(DEFAULT_PKL_VERSION),
     executable = True,
     toolchains = [
         ":current_toolchain",


### PR DESCRIPTION
This change adds support for integration testing against both Bazel 7 and Bazel 8. It updates the path resolved for `PKL_BIN` as well as any `pkl_project` extension usage to account for changes in Bazel 8.

### Related issues

- https://github.com/bazelbuild/bazel/issues/23127
- https://github.com/bazelbuild/bazel/issues/25198