### PR TITLE
Use `rules_python` and `rules_java` everywhere; not `native.` or raw

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,7 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.13.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_java", version = "8.11.0")
 bazel_dep(name = "rules_jvm_external", version = "6.7")
 bazel_dep(name = "rules_shell", version = "0.4.0")
@@ -31,6 +31,7 @@ bazel_dep(name = "rules_shell", version = "0.4.0")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.43.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_bazel_integration_test", version = "0.29.0", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.3.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
 
 pkl = use_extension("//pkl/extensions:pkl.bzl", "pkl")
@@ -85,6 +86,17 @@ use_repo(
     maven,
     "custom_pkl_java_library_maven_deps",
     "unpinned_custom_pkl_java_library_maven_deps",
+)
+
+python = use_extension(
+    "@rules_python//python/extensions:python.bzl",
+    "python",
+    dev_dependency = True,
+)
+python.toolchain(
+    configure_coverage_tool = True,
+    ignore_root_user_error = True,
+    python_version = "3.12",
 )
 
 bazel_binaries = use_extension(

--- a/pkl/private/BUILD.bazel
+++ b/pkl/private/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 

--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -16,6 +16,7 @@
 Implementation for 'pkl_java_library' macro.
 """
 
+load("@rules_java//java:defs.bzl", "JavaInfo", "java_library")
 load("@rules_pkl//pkl/private:providers.bzl", "PklCacheInfo", "PklFileInfo")
 
 def _to_short_path(f, _expander):
@@ -147,7 +148,7 @@ def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps
         transitive = depsets,
     )
 
-    native.java_library(
+    java_library(
         name = name,
         srcs = [name_generated_code],
         deps = all_deps.to_list(),

--- a/tests/pkl_codegen_java/BUILD.bazel
+++ b/tests/pkl_codegen_java/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("@rules_pkl//pkl:defs.bzl", "pkl_java_library")
 

--- a/tests/pkl_codegen_java/tests/pkl_java_library_deps_test.bzl
+++ b/tests/pkl_codegen_java/tests/pkl_java_library_deps_test.bzl
@@ -18,6 +18,7 @@ use by a given `pkl_java_library` target.
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_java//java:defs.bzl", "JavaInfo")
 
 def _pkl_java_library_deps_test_impl(ctx):
     env = analysistest.begin(ctx)

--- a/tests/pkl_doc/BUILD.bazel
+++ b/tests/pkl_doc/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_test")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//pkl:defs.bzl", "pkl_doc")
 

--- a/tests/pkl_library/BUILD.bazel
+++ b/tests/pkl_library/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_test")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//pkl:defs.bzl", "pkl_library")
 

--- a/tests/version/BUILD.bazel
+++ b/tests/version/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:defs.bzl", "py_binary")
+
 py_binary(
     name = "version_test",
     srcs = ["version_test.py"],


### PR DESCRIPTION
Both of these fixes were found with `bazel test --incompatible_autoload_externally= //...` on Bazel 8.2.1. Specifically the error `name '<rule-name-here>' is not defined`.

This relates to #82.

- Use `rules_python` for `py_binary`
- Use `rules_java` everywhere for `java_` rules