### PR TITLE
`pkl_java_deps`: convert `string` types we're passed into `Label`

### DIFF
--- a/pkl/private/pkl_codegen_java.bzl
+++ b/pkl/private/pkl_codegen_java.bzl
@@ -142,6 +142,9 @@ def pkl_java_library(name, srcs, module_path = [], generate_getters = None, deps
         tags = tags,
     )
 
+    # As this is a macro, make sure we're only dealing with labels.
+    pkl_java_deps = [Label(dep) for dep in pkl_java_deps]
+
     # Ensure that there are no duplicate entries in the deps
     all_deps = depset(
         pkl_java_deps + [native.package_relative_label(m) for m in module_path],


### PR DESCRIPTION
`Label()` is idempotent; it returns existing Labels unchanged, converting strings to Labels.

This deals with the following error:

```
Error in depset: cannot add an item of type 'Label' to a depset of 'string'
```