### PR TITLE
Support building pkl rules from external workspace

### DIFF
--- a/pkl/private/run_pkl_script.sh
+++ b/pkl/private/run_pkl_script.sh
@@ -66,6 +66,11 @@ if [[ -n "$cache_dir" ]]; then
   cache_args=("--cache-dir" "../cache")
 fi
 
+# The ruleset currently assumes the {label}/work directory exists due to creation of the symlinks
+# However when running a `pkl_eval` frome external to the workspsace, the symlinks exist external 
+# to the {label}/work directory and it is not created, causing the command below to have issues.
+mkdir -p "${working_dir}"
+
 output=$($executable "$command" $format_args "${properties_and_expressions[@]}" $expression_args --working-dir "${working_dir}" "${cache_args[@]}" "${output_args[@]}" $entrypoints)
 
 ret=$?


### PR DESCRIPTION
Ran into a bug that blocked us from building pkls from outside the workspace they are defined in.

There was a slight bug where the pkl-cli binary expects the `/work` directory to be created by one of the symlinks but in the case of a pkl that is defined completely externally nothing lives under the current workspace so none of the symlinks ever create the work directory and then the pkl-cli binary looks for the import in the wrong place