### PR TITLE
Clean up BCR configuration to remove `patches`

### DIFF
--- a/scripts/prep-bcr-pr.sh
+++ b/scripts/prep-bcr-pr.sh
@@ -22,12 +22,6 @@ ARCHIVE_URL="https://github.com/apple/rules_pkl/releases/download/v${VERSION}/ru
 RULES_PKL_DIR="$(bazel info workspace)"
 INPUT_JSON="$(mktemp)"
 
-# Patch the version number in our MODULE.bazel
-cat MODULE.bazel | \
-  awk -vversion=${VERSION} 'BEGIN {matched=0} /version = / {if (matched) { print $0 } else { print "    version = \"" version "\","; matched=1}} !/version = / {print $0}' >MODULE.tmp && \
-  mv MODULE.tmp MODULE.bazel
-git diff MODULE.bazel >"${RULES_PKL_DIR}/update-version.patch"
-
 cd "${BCR_REPO}"
 
 # Create the input file so we don't need to be prompted for anything
@@ -35,25 +29,20 @@ cat >"${INPUT_JSON}" <<EOF
 {
     "build_file": null,
     "build_targets": [
-        "@rules_pkl//..."
+        "@rules_pkl//pkl/..."
     ],
     "compatibility_level": "1",
     "deps": [],
     "module_dot_bazel": "${RULES_PKL_DIR}/MODULE.bazel",
     "name": "rules_pkl",
-    "patch_strip": 1,
-    "patches": [
-        "${RULES_PKL_DIR}/update-version.patch"
-    ],
+    "patches": [],
     "presubmit_yml": null,
     "strip_prefix": "rules_pkl-${VERSION}",
     "test_module_build_targets": [
         "//..."
     ],
-    "test_module_path": "examples/pkl_project",
-    "test_module_test_targets": [
-        "//..."
-    ],
+    "test_module_test_targets": [],
+    "test_module_path": "examples",
     "url": "${ARCHIVE_URL}",
     "version": "${VERSION}"
 }


### PR DESCRIPTION
The result of this is that our `souces.json` files no longer contain this content:

```
"patches": {
    "update-version.patch": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
},
"patch_strip": 1
```

Set `test_module_test_targets` to an empty value as BCR CI can't run `rules_bazel_integration_test` tests.