### PR TITLE
build: update rules_bazel_integration_test Bazel dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,7 @@ bazel_dep(name = "rules_shell", version = "0.4.0")
 
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.44.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_bazel_integration_test", version = "0.34.0", dev_dependency = True)
 bazel_dep(name = "rules_python", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
 
@@ -96,10 +97,6 @@ python.toolchain(
     ignore_root_user_error = True,
     python_version = "3.12",
 )
-
-# moved here due to python toolchain resolution order issue.
-# rules_bazel_integration_test needs to be declared after python.toolchain
-bazel_dep(name = "rules_bazel_integration_test", version = "0.29.0", dev_dependency = True)
 
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",


### PR DESCRIPTION
Version 0.34.0 contains a fix that ensures that the hermetic python toolchain used by the project is not overridden by the un-hermetic one defined in rules_bazel_integration_test.