### PR TITLE
Handle slash in pkl_test target name

### DIFF
--- a/pkl/private/pkl.bzl
+++ b/pkl/private/pkl.bzl
@@ -85,7 +85,9 @@ def _prepare_pkl_script(ctx, is_test_target):
     suite_name_parts = []
     if is_test_target:
         package_parts = [part for part in ctx.label.package.split("/") if part != ""]
-        suite_name_parts = package_parts + [ctx.label.name]
+
+        label_parts = [part for part in ctx.label.name.split("/") if part != ""]
+        suite_name_parts = package_parts + label_parts
 
     # The 'args' lists for 'pkl_eval' and 'pkl_test' differ because for `pkl_eval`, files are passed as file targets to enable
     # path stripping on the `ctx.Args` object when using the '--experimental_output_path=strip' flag. Currently, test rules

--- a/tests/junit_xml/BUILD.bazel
+++ b/tests/junit_xml/BUILD.bazel
@@ -17,7 +17,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # Sample pkl test for XML generation
 pkl_test(
-    name = "sample_xml_generator",
+    name = "sample_xml_generator/name",
     srcs = ["sample_xml_test.pkl"],
 )
 
@@ -25,8 +25,8 @@ pkl_test(
 py_test(
     name = "junit_xml_validation_test",
     srcs = ["junit_xml_validation_test.py"],
-    data = [":sample_xml_generator"],
+    data = [":sample_xml_generator/name"],
     env = {
-        "SAMPLE_XML_GENERATOR_PATH": "$(location :sample_xml_generator)",
+        "SAMPLE_XML_GENERATOR_PATH": "$(location :sample_xml_generator/name)",
     },
 )

--- a/tests/junit_xml/junit_xml_validation_test.py
+++ b/tests/junit_xml/junit_xml_validation_test.py
@@ -85,7 +85,7 @@ class JUnitXMLValidationTest(unittest.TestCase):
             missing_attrs, f"testsuites missing attributes: {missing_attrs}"
         )
 
-        self.assertEqual(root.attrib["name"], "tests.junit_xml.sample_xml_generator")
+        self.assertEqual(root.attrib["name"], "tests.junit_xml.sample_xml_generator.name")
 
     def test_testsuite_structure(self):
         testsuites = self.xml_root.findall("testsuite")
@@ -127,7 +127,7 @@ class JUnitXMLValidationTest(unittest.TestCase):
         self.assertIn("<?xml version", content, "XML declaration not found")
 
     def test_suite_name_matches_target(self):
-        expected_name = "tests.junit_xml.sample_xml_generator"
+        expected_name = "tests.junit_xml.sample_xml_generator.name"
         self.assertEqual(
             self.xml_root.attrib["name"],
             expected_name,


### PR DESCRIPTION
`pkl_test_suite` produces tests with `/` in target name, which previously was causing errors like:
```
An unexpected error has occurred. Would you mind filing a bug report?
     
     java.io.FileNotFoundException: mpackage/path/work/target/name/with_slash_test.xml (No such file or directory)
     	at java.base/java.io.FileOutputStream.open0(Native Method)
     	at java.base/java.io.FileOutputStream.open(FileOutputStream.java:289)
     	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:230)
     	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:179)
     	at java.base/java.io.FileWriter.<init>(FileWriter.java:179)
     	at org.pkl.core.stdlib.test.report.TestReport.summarizeToPath(TestReport.java:52)
```