### PR TITLE
fix: propagate version attr in pkl_package provider

### DIFF
--- a/pkl/private/pkl_package.bzl
+++ b/pkl/private/pkl_package.bzl
@@ -23,6 +23,7 @@ def _pkl_package_impl(ctx):
     executable = pkl_toolchain.cli[DefaultInfo].files_to_run.executable
 
     project_metadata_info = ctx.attr.project[PklMetadataInfo]
+    pkl_project_base_uri = project_metadata_info.base_uri
     pkl_project_file = project_metadata_info.pkl_project_file
     pkl_project_deps = project_metadata_info.pkl_project_deps
     pkl_project_name = project_metadata_info.pkl_project_name
@@ -33,6 +34,16 @@ def _pkl_package_impl(ctx):
     if ctx.attr.version:
         pkl_project_version = ctx.attr.version
         extra_flags.append("--env-var=PKL_PACKAGE_VERSION={}".format(ctx.attr.version))
+
+        # The provider we pass along also needs to have the updated version.
+        # TODO: This API is quite awkward; change it to (only) evaluate name/version/base_uri in pkl_package instead.
+        project_metadata_info = PklMetadataInfo(
+            base_uri = pkl_project_base_uri,
+            pkl_project_file = pkl_project_file,
+            pkl_project_deps = pkl_project_deps,
+            pkl_project_name = pkl_project_name,
+            pkl_project_version = pkl_project_version,
+        )
 
     artifact_prefix = "{name}@{version}".format(name = pkl_project_name, version = pkl_project_version)
 


### PR DESCRIPTION
Ensure that a version passed as an attribute to `pkl_package` is correctly propagated through the provider. Previously, the pkl_package rule would propagate the initial version resolved at repo_rule fetching time, which may not match the one evaluated at build time.