### PR TITLE
build: disable integration tests on GHA

### DIFF
--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -65,7 +65,7 @@ local test: Workflow = new {
         }
         new {
           name = "Bazel test"
-          run = "bazel test --config=ci //..."
+          run = "bazel test --config=ci -- //... -//tests/integration_tests/..."
         }
       }
     }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         WORKING_DIRECTORY: ${{ github.workspace }}
       run: bazel run --config=ci //tests/version:version_test -- --verbose
     - name: Bazel test
-      run: bazel test --config=ci //...
+      run: bazel test --config=ci -- //... -//tests/integration_tests/...
     - name: Publish test results
       if: '!cancelled()'
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         WORKING_DIRECTORY: ${{ github.workspace }}
       run: bazel run --config=ci //tests/version:version_test -- --verbose
     - name: Bazel test
-      run: bazel test --config=ci //...
+      run: bazel test --config=ci -- //... -//tests/integration_tests/...
     - name: Publish test results
       if: '!cancelled()'
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -30,7 +30,7 @@ jobs:
         WORKING_DIRECTORY: ${{ github.workspace }}
       run: bazel run --config=ci //tests/version:version_test -- --verbose
     - name: Bazel test
-      run: bazel test --config=ci //...
+      run: bazel test --config=ci -- //... -//tests/integration_tests/...
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5


### PR DESCRIPTION
The project doesn't have a functional CI on Github at the moment, and integration tests are timing out on the Github Action workflow, see e.g. https://github.com/apple/rules_pkl/actions/runs/19446439893/job/55642006324

Disabling bazel integration tests on github actions to unblock the GHA works.