### PR TITLE
build: use consistent bazel configuration in GHA steps

### DIFF
--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -45,25 +45,6 @@ local test: Workflow = new {
           }
         }
         new {
-          name = "Buildifier lint"
-          run = "bazel run --config=ci buildifier"
-        }
-        new {
-          name = "Check gazelle"
-          run =
-            """
-            bazel run --config=ci //:gazelle
-            git diff --exit-code
-            """
-        }
-        new {
-          name = "Bazel version consistency"
-          env {
-            ["WORKING_DIRECTORY"] = Context.github.workspace
-          }
-          run = "bazel run --config=ci //tests/version:version_test -- --verbose"
-        }
-        new {
           name = "Update integration test repos .bazelrc (debug information and caching)"
           run = """
             # Assign a separate output base to the integration tests: it needs to be explicitly set, and set as a
@@ -83,6 +64,25 @@ local test: Workflow = new {
             sed -i '/^startup --output_base/d' /home/runner/.bazelrc
             printf '%s\\n' "$output_base_line" > /home/runner/.bazelrc.cmdline
             """
+        }
+        new {
+          name = "Buildifier lint"
+          run = "bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci buildifier"
+        }
+        new {
+          name = "Check gazelle"
+          run =
+            """
+            bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci //:gazelle
+            git diff --exit-code
+            """
+        }
+        new {
+          name = "Bazel version consistency"
+          env {
+            ["WORKING_DIRECTORY"] = Context.github.workspace
+          }
+          run = "bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci //tests/version:version_test -- --verbose"
         }
         new {
           name = "Bazel test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,16 +26,6 @@ jobs:
         bazelisk-cache: true
         disk-cache: ${{ matrix.os }}-cache
         repository-cache: true
-    - name: Buildifier lint
-      run: bazel run --config=ci buildifier
-    - name: Check gazelle
-      run: |-
-        bazel run --config=ci //:gazelle
-        git diff --exit-code
-    - name: Bazel version consistency
-      env:
-        WORKING_DIRECTORY: ${{ github.workspace }}
-      run: bazel run --config=ci //tests/version:version_test -- --verbose
     - name: Update integration test repos .bazelrc (debug information and caching)
       run: |-
         # Assign a separate output base to the integration tests: it needs to be explicitly set, and set as a
@@ -54,6 +44,16 @@ jobs:
         output_base_line=$(grep '^startup --output_base' /home/runner/.bazelrc | tail -1)
         sed -i '/^startup --output_base/d' /home/runner/.bazelrc
         printf '%s\n' "$output_base_line" > /home/runner/.bazelrc.cmdline
+    - name: Buildifier lint
+      run: bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci buildifier
+    - name: Check gazelle
+      run: |-
+        bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci //:gazelle
+        git diff --exit-code
+    - name: Bazel version consistency
+      env:
+        WORKING_DIRECTORY: ${{ github.workspace }}
+      run: bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci //tests/version:version_test -- --verbose
     - name: Bazel test
       run: bazel --bazelrc=/home/runner/.bazelrc.cmdline test --config=ci -- //...
     - name: Publish test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,6 @@ jobs:
         bazelisk-cache: true
         disk-cache: ${{ matrix.os }}-cache
         repository-cache: true
-    - name: Buildifier lint
-      run: bazel run --config=ci buildifier
-    - name: Check gazelle
-      run: |-
-        bazel run --config=ci //:gazelle
-        git diff --exit-code
-    - name: Bazel version consistency
-      env:
-        WORKING_DIRECTORY: ${{ github.workspace }}
-      run: bazel run --config=ci //tests/version:version_test -- --verbose
     - name: Update integration test repos .bazelrc (debug information and caching)
       run: |-
         # Assign a separate output base to the integration tests: it needs to be explicitly set, and set as a
@@ -53,6 +43,16 @@ jobs:
         output_base_line=$(grep '^startup --output_base' /home/runner/.bazelrc | tail -1)
         sed -i '/^startup --output_base/d' /home/runner/.bazelrc
         printf '%s\n' "$output_base_line" > /home/runner/.bazelrc.cmdline
+    - name: Buildifier lint
+      run: bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci buildifier
+    - name: Check gazelle
+      run: |-
+        bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci //:gazelle
+        git diff --exit-code
+    - name: Bazel version consistency
+      env:
+        WORKING_DIRECTORY: ${{ github.workspace }}
+      run: bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci //tests/version:version_test -- --verbose
     - name: Bazel test
       run: bazel --bazelrc=/home/runner/.bazelrc.cmdline test --config=ci -- //...
     - name: Publish test results

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -19,16 +19,6 @@ jobs:
         bazelisk-cache: true
         disk-cache: ${{ matrix.os }}-cache
         repository-cache: true
-    - name: Buildifier lint
-      run: bazel run --config=ci buildifier
-    - name: Check gazelle
-      run: |-
-        bazel run --config=ci //:gazelle
-        git diff --exit-code
-    - name: Bazel version consistency
-      env:
-        WORKING_DIRECTORY: ${{ github.workspace }}
-      run: bazel run --config=ci //tests/version:version_test -- --verbose
     - name: Update integration test repos .bazelrc (debug information and caching)
       run: |-
         # Assign a separate output base to the integration tests: it needs to be explicitly set, and set as a
@@ -47,6 +37,16 @@ jobs:
         output_base_line=$(grep '^startup --output_base' /home/runner/.bazelrc | tail -1)
         sed -i '/^startup --output_base/d' /home/runner/.bazelrc
         printf '%s\n' "$output_base_line" > /home/runner/.bazelrc.cmdline
+    - name: Buildifier lint
+      run: bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci buildifier
+    - name: Check gazelle
+      run: |-
+        bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci //:gazelle
+        git diff --exit-code
+    - name: Bazel version consistency
+      env:
+        WORKING_DIRECTORY: ${{ github.workspace }}
+      run: bazel --bazelrc=/home/runner/.bazelrc.cmdline run --config=ci //tests/version:version_test -- --verbose
     - name: Bazel test
       run: bazel --bazelrc=/home/runner/.bazelrc.cmdline test --config=ci -- //...
     - name: Upload Test Result XML


### PR DESCRIPTION
This ensures they use the same output base, which should make the overall build a bit faster.