### PR TITLE
fix: update rules_java module to 9.4.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,7 +24,7 @@ module(
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_java", version = "9.1.0")
+bazel_dep(name = "rules_java", version = "9.4.0")
 bazel_dep(name = "rules_jvm_external", version = "6.7")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 


### PR DESCRIPTION
Prior versions of rules_java 9.x were failing on bazel 7.6.x